### PR TITLE
Refactor CLI commands and enhance validation service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -169,6 +169,12 @@ services:
     image: ${LOKI_IMAGE}
     command:
       - -config.file=/etc/loki/loki-config.yml
+      - -config.expand-env=true
+    environment:
+      AWS_REGION: ${AWS_REGION}
+      S3_BUCKET: ${S3_BUCKET}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     volumes:
       - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
       - loki-data:/loki
@@ -219,6 +225,7 @@ services:
     ports:
       - "${GRAFANA_PORT}:${GRAFANA_PORT}"
 
+# declare volume explictly
 volumes:
   prometheus-data:
   loki-data:

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -13,6 +13,8 @@ type StatusResponse struct {
 // ValidateRequest is the request body for POST /validate and POST /dryrun.
 type ValidateRequest struct {
 	YAMLContent string `json:"yaml_content"`
+	Commit string `json:"commit"`
+	PipelinePath string `json:"pipeline_path"`
 }
 
 // ValidateResponse is the response for POST /validate.

--- a/internal/cache/keys.go
+++ b/internal/cache/keys.go
@@ -1,35 +1,34 @@
 package cache
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"strings"
 )
 
 const (
-	validateNamespace = "validate:v1"
-	dryRunNamespace   = "dryrun:v1"
+	validateNamespace = "validate:v2"
+	dryRunNamespace   = "dryrun:v2"
 )
 
 // ValidateKey returns a stable redis key for validate response cache.
-func ValidateKey(prefix, yamlContent string) string {
-	return buildKey(prefix, validateNamespace, yamlContent)
+func ValidateKey(prefix, path, commit string) string {
+	return buildKey(prefix, validateNamespace, path, commit)
 }
 
 // DryRunKey returns a stable redis key for dryrun response cache.
-func DryRunKey(prefix, yamlContent string) string {
-	return buildKey(prefix, dryRunNamespace, yamlContent)
+func DryRunKey(prefix, path, commit string) string {
+	return buildKey(prefix, dryRunNamespace, path, commit)
 }
 
-func buildKey(prefix, namespace, content string) string {
-	sum := sha256.Sum256([]byte(content))
-	hash := hex.EncodeToString(sum[:])
+func buildKey(prefix, namespace, path, commit string) string {
+	path = strings.TrimSpace(path)
+	commit = strings.TrimSpace(commit)
+
+	val := commit + ":" + path
 
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {
-		return namespace + ":" + hash
+		return namespace + ":" + val
 	}
 
-	return prefix + ":" + namespace + ":" + hash
+	return prefix + ":" + namespace + ":" + val
 }
-

--- a/internal/cache/keys_test.go
+++ b/internal/cache/keys_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 func TestValidateKeyAndDryRunKey_StableAndDifferentNamespaces(t *testing.T) {
-	content := "pipeline:\n  name: demo\n"
-	v1 := ValidateKey("cicd", content)
-	v2 := ValidateKey("cicd", content)
-	d1 := DryRunKey("cicd", content)
+	path := "build.yaml"
+	commit := "abc123"
+	v1 := ValidateKey("cicd", path, commit)
+	v2 := ValidateKey("cicd", path, commit)
+	d1 := DryRunKey("cicd", path, commit)
 
 	if v1 != v2 {
 		t.Fatalf("ValidateKey not stable: %q != %q", v1, v2)
@@ -17,18 +18,20 @@ func TestValidateKeyAndDryRunKey_StableAndDifferentNamespaces(t *testing.T) {
 	if v1 == d1 {
 		t.Fatalf("ValidateKey and DryRunKey should differ, both=%q", v1)
 	}
-	if !strings.HasPrefix(v1, "cicd:validate:v1:") {
+	if !strings.HasPrefix(v1, "cicd:validate:v2:") {
 		t.Fatalf("unexpected validate key prefix: %q", v1)
 	}
-	if !strings.HasPrefix(d1, "cicd:dryrun:v1:") {
+	if !strings.HasPrefix(d1, "cicd:dryrun:v2:") {
 		t.Fatalf("unexpected dryrun key prefix: %q", d1)
+	}
+	if !strings.HasSuffix(v1, "abc123:build.yaml") {
+		t.Fatalf("unexpected validate key suffix: %q", v1)
 	}
 }
 
 func TestKeyWithoutPrefix(t *testing.T) {
-	k := ValidateKey("", "x")
-	if !strings.HasPrefix(k, "validate:v1:") {
+	k := ValidateKey("", "build.yaml", "abc123")
+	if !strings.HasPrefix(k, "validate:v2:") {
 		t.Fatalf("unexpected key: %q", k)
 	}
 }
-

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/xueyulinn/cicd-system/internal/api"
 	"github.com/xueyulinn/cicd-system/internal/common/formatter"
-	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
 	"github.com/xueyulinn/cicd-system/internal/common/pipelinepath"
 	"github.com/xueyulinn/cicd-system/internal/models"
 )
@@ -37,9 +36,9 @@ func init() {
 }
 
 func runDryRun(cmd *cobra.Command, args []string) error {
-	repo, ok := cmd.Context().Value(repoKey).(*gitutil.Repository)
-	if !ok || repo == nil {
-		return fmt.Errorf("git repository context is missing")
+	repo, err := repoFromCommandContext(cmd)
+	if err != nil {
+		return err
 	}
 	rootDir := repo.Root()
 
@@ -62,10 +61,10 @@ func runDryRun(cmd *cobra.Command, args []string) error {
 
 	// Call gateway for dry run
 	response, err := client.DryRun(api.ValidateRequest{
-		YAMLContent: string(pipelineData),
-		Commit: commit,
+		YAMLContent:  string(pipelineData),
+		Commit:       commit,
 		PipelinePath: filepath.Base(completePath),
-		},
+	},
 	)
 	if err != nil {
 		return fmt.Errorf("dry run failed, error: %w", err)

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -25,7 +25,7 @@ var dryRunCmd = &cobra.Command{
 	Long:                  "Validates the specified pipeline file and prints the execution plan without running any jobs. Output defaults to YAML and can be changed with --format json.",
 	Example:               "cicd dryrun .pipelines/pipeline.yaml\ncicd dryrun .pipelines/pipeline.yaml --format json",
 	Args:                  cobra.ExactArgs(1),
-	PreRunE:               runVerifyQuiet,
+	PreRunE:               runValidateQuiet,
 	RunE:                  runDryRun,
 	DisableFlagsInUseLine: true,
 }
@@ -109,8 +109,8 @@ func formatOutput(plan *models.ExecutionPlan, format string) (string, error) {
 	return string(out), nil
 }
 
-// runVerifyQuiet runs the verify command but redirects stdout to /dev/null
-func runVerifyQuiet(cmd *cobra.Command, args []string) error {
+// runValidateQuiet runs the validate command but redirects stdout to /dev/null.
+func runValidateQuiet(cmd *cobra.Command, args []string) error {
 	devNull, err := os.Open(os.DevNull)
 	if err != nil {
 		return err
@@ -119,5 +119,5 @@ func runVerifyQuiet(cmd *cobra.Command, args []string) error {
 	stdout := os.Stdout
 	os.Stdout = devNull
 	defer func() { os.Stdout = stdout }()
-	return runVerify(cmd, args)
+	return runValidate(cmd, args)
 }

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -10,6 +10,7 @@ import (
 	"github.com/xueyulinn/cicd-system/internal/api"
 	"github.com/xueyulinn/cicd-system/internal/common/formatter"
 	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
+	"github.com/xueyulinn/cicd-system/internal/common/pipelinepath"
 	"github.com/xueyulinn/cicd-system/internal/models"
 )
 
@@ -36,30 +37,36 @@ func init() {
 }
 
 func runDryRun(cmd *cobra.Command, args []string) error {
-	repo, err := gitutil.Open(".")
+	repo, ok := cmd.Context().Value(repoKey).(*gitutil.Repository)
+	if !ok || repo == nil {
+		return fmt.Errorf("git repository context is missing")
+	}
+	rootDir := repo.Root()
+
+	completePath, _, err := pipelinepath.ResolveInputPath(rootDir, args[0])
 	if err != nil {
 		return err
 	}
-	rootDir := repo.Root()
-	pipelinePath := args[0]
 
-	completePath := pipelinePath
-	if !filepath.IsAbs(pipelinePath) {
-		completePath = filepath.Join(rootDir, pipelinePath)
-	}
-	completePath = filepath.Clean(completePath)
-
-	// Read file content
-	fileContent, err := os.ReadFile(completePath)
+	commit, err := repo.GetHeadCommit()
 	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
+		return fmt.Errorf("get head commit failed: %w", err)
 	}
 
-	// Create gateway client
+	pipelineData, err := repo.ReadFileAtCommit(commit, completePath)
+	if err != nil {
+		return fmt.Errorf("read pipeline file failed: %w", err)
+	}
+
 	client := NewGatewayClient()
 
 	// Call gateway for dry run
-	response, err := client.DryRun(api.ValidateRequest{YAMLContent: string(fileContent)})
+	response, err := client.DryRun(api.ValidateRequest{
+		YAMLContent: string(pipelineData),
+		Commit: commit,
+		PipelinePath: filepath.Base(completePath),
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("dry run failed, error: %w", err)
 	}

--- a/internal/cli/dryrun.go
+++ b/internal/cli/dryrun.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/xueyulinn/cicd-system/internal/api"
+	"github.com/xueyulinn/cicd-system/internal/common/formatter"
 	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
 	"github.com/xueyulinn/cicd-system/internal/models"
 )
@@ -97,9 +98,9 @@ func formatOutput(plan *models.ExecutionPlan, format string) (string, error) {
 	)
 	switch format {
 	case formatYAML:
-		out, err = FormatExecutionPlanYAML(plan)
+		out, err = formatter.FormatExecutionPlanYAML(plan)
 	case formatJSON:
-		out, err = FormatExecutionPlanJSON(plan)
+		out, err = formatter.FormatExecutionPlanJSON(plan)
 	default:
 		return "", fmt.Errorf("invalid format %q (supported: yaml, json)", format)
 	}

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -1,8 +1,7 @@
 package cli
 
 import (
-	"os"
-	"path/filepath"
+	"context"
 	"strings"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 func TestRunDryRun_PrintsOrderedJobs(t *testing.T) {
 	startValidationGatewayServer(t)
 
-	configPath := writeTempPipeline(t, `
+	configPath, cleanup := writeTempPipelineInGitRepo(t, `
 pipeline:
   name: "Test Pipeline"
 
@@ -39,9 +38,12 @@ integration-tests:
   - script:
     - "make integration"
 `)
+	defer cleanup()
+
+	cmd := newRepoContextCommand(t)
 
 	output, err := captureStdout(t, func() error {
-		return runDryRun(&cobra.Command{}, []string{configPath})
+		return runDryRun(cmd, []string{configPath})
 	})
 	if err != nil {
 		t.Fatalf("runDryRun returned error: %v", err)
@@ -69,7 +71,7 @@ integration-tests:
 func TestRunDryRun_FailsOnEmptyStage(t *testing.T) {
 	startValidationGatewayServer(t)
 
-	configPath := writeTempPipeline(t, `
+	configPath, cleanup := writeTempPipelineInGitRepo(t, `
 pipeline:
   name: "Test Pipeline"
 
@@ -83,9 +85,12 @@ compile:
   - script:
     - "make build"
 `)
+	defer cleanup()
+
+	cmd := newRepoContextCommand(t)
 
 	_, err := captureStdout(t, func() error {
-		return runDryRun(&cobra.Command{}, []string{configPath})
+		return runDryRun(cmd, []string{configPath})
 	})
 	if err == nil {
 		t.Fatal("Expected error for stage with no jobs, got nil")
@@ -171,12 +176,13 @@ func runDryRunCommand(t *testing.T, configPath string) (string, error) {
 	})
 }
 
-func writeTempPipeline(t *testing.T, content string) string {
+func newRepoContextCommand(t *testing.T) *cobra.Command {
 	t.Helper()
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "pipeline.yaml")
-	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {
-		t.Fatalf("Failed to write pipeline file: %v", err)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := openGitRepo(cmd, nil); err != nil {
+		t.Fatalf("openGitRepo: %v", err)
 	}
-	return path
+	return cmd
 }

--- a/internal/cli/repo_context.go
+++ b/internal/cli/repo_context.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
+)
+
+func repoFromCommandContext(cmd *cobra.Command) (*gitutil.Repository, error) {
+	if cmd == nil {
+		return nil, fmt.Errorf("git repository context is missing")
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		return nil, fmt.Errorf("git repository context is missing")
+	}
+
+	repo, ok := ctx.Value(repoKey).(*gitutil.Repository)
+	if !ok || repo == nil {
+		return nil, fmt.Errorf("git repository context is missing")
+	}
+
+	return repo, nil
+}

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/xueyulinn/cicd-system/internal/common/formatter"
 	"github.com/xueyulinn/cicd-system/internal/models"
 )
 
 var (
-	reportRun      int
-	reportStage    string
-	reportJob      string
+	reportRun   int
+	reportStage string
+	reportJob   string
 )
 
 var reportCmd = &cobra.Command{
@@ -70,9 +71,9 @@ func formatReport(report *models.ReportResponse, format string) ([]byte, error) 
 	var err error
 	switch format {
 	case formatJSON:
-		out, err = FormatReportJSON(report)
+		out, err = formatter.FormatReportJSON(report)
 	default:
-		out, err = FormatReportYAML(report)
+		out, err = formatter.FormatReportYAML(report)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,16 +1,23 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
 )
+
+type repoContextKey struct{}
+var repoKey = repoContextKey{}
 
 var rootCmd = &cobra.Command{
 	Use:           "cicd",
 	Short:         "CI/CD pipeline management tool",
+	Long: "",
+	PersistentPreRunE: openGitRepo,
 	SilenceErrors: true,
 	SilenceUsage:  true,
 }
@@ -21,6 +28,17 @@ func init() {
 	rootCmd.AddCommand(reportCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(dryRunCmd)
+}
+
+func openGitRepo(cmd *cobra.Command, args []string) error {
+	gitRepo, err := gitutil.Open(".")
+	if err != nil {
+		return fmt.Errorf("validate, dryrun, run commands can only run within a git repo: %w", err)
+	}
+	
+	ctx := context.WithValue(cmd.Context(), repoKey, gitRepo)
+	cmd.SetContext(ctx)
+	return nil
 }
 
 // Execute runs the root command.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,15 +11,28 @@ import (
 )
 
 type repoContextKey struct{}
+
 var repoKey = repoContextKey{}
 
 var rootCmd = &cobra.Command{
-	Use:           "cicd",
-	Short:         "CI/CD pipeline management tool",
-	Long: "",
+	Use:   "cicd",
+	Short: "Manage CI/CD pipelines from the current repository",
+	Long: strings.Join([]string{
+		"Validate pipeline definitions, preview execution plans, inspect run reports,",
+		"and execute pipelines from the command line.",
+		"",
+		"Most commands resolve files relative to the current Git repository, so run",
+		"them from inside the repository that owns the pipeline files.",
+	}, "\n"),
+	Example: strings.Join([]string{
+		"  cicd validate ./.pipelines/build.yaml",
+		"  cicd dryrun ./.pipelines/build.yaml",
+		"  cicd run --name DefaultPipeline --branch main",
+		"  cicd report DefaultPipeline --run 1",
+	}, "\n"),
 	PersistentPreRunE: openGitRepo,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	SilenceErrors:     true,
+	SilenceUsage:      true,
 }
 
 func init() {
@@ -35,7 +48,7 @@ func openGitRepo(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("validate, dryrun, run commands can only run within a git repo: %w", err)
 	}
-	
+
 	ctx := context.WithValue(cmd.Context(), repoKey, gitRepo)
 	cmd.SetContext(ctx)
 	return nil

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,7 +17,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	// register all subcommands
-	rootCmd.AddCommand(verifyCmd)
+	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(reportCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(dryRunCmd)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/xueyulinn/cicd-system/internal/api"
 	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
 	"github.com/xueyulinn/cicd-system/internal/common/parser"
+	"github.com/xueyulinn/cicd-system/internal/common/pipelinepath"
 	"github.com/xueyulinn/cicd-system/internal/config"
 )
 
@@ -22,7 +23,7 @@ var (
 )
 
 var runCmd = &cobra.Command{
-	Use:     "run {pipeline-path | pipeline-name} [--branch branch] [--commit commit] [--remote]",
+	Use:     "run {--file pipeline-path | --name pipeline-name} [--branch branch] [--commit commit] [--remote]",
 	Short:   "Run a pipeline",
 	Long:    "Run a pipeline with the given name or file. For the initial iteration, all pipeline executions happen locally.",
 	// Args:    cobra.ExactArgs(1),
@@ -128,10 +129,11 @@ func runPreRunE(cmd *cobra.Command, args []string) error {
 // runRun executes a pipeline against a temporary worktree for the resolved
 // commit so file reads and job execution use a consistent repository snapshot.
 func runRun(cmd *cobra.Command, args []string) error {
-	repo, err := gitutil.Open(".")
-	if err != nil {
-		return err
+	repo, ok := cmd.Context().Value(repoKey).(*gitutil.Repository)
+	if !ok || repo == nil {
+		return fmt.Errorf("git repository context is missing")
 	}
+	rootDir := repo.Root()
 
 	client := NewGatewayClient()
 	req := api.RunRequest{
@@ -146,17 +148,17 @@ func runRun(cmd *cobra.Command, args []string) error {
 		}
 		// defer cleanup()
 
-		runFileAtCommit, err := resolveRunFileInWorkspace(runFile, repo.Root(), worktree)
+		completePath, _, err := pipelinepath.ResolveInputPath(rootDir, runFile)
 		if err != nil {
-			return fmt.Errorf("failed to resolve run file %q in commit workspace: %w", runFile, err)
+			return err
 		}
 
-		fileContent, err := os.ReadFile(runFileAtCommit)
+		pipelineData, err := repo.ReadFileAtCommit(runCommit, completePath)
 		if err != nil {
-			return fmt.Errorf("failed to read run file at commit %q: %w", runCommit, err)
+			return fmt.Errorf("read pipeline file failed: %w", err)
 		}
 
-		req.YAMLContent = string(fileContent)
+		req.YAMLContent = string(pipelineData)
 		req.RepoURL = ""
 		req.WorkspacePath = worktree
 	} else {
@@ -236,29 +238,4 @@ func findPipelineByName(name string, root string) (string, error) {
 	}
 
 	return "", fmt.Errorf("pipeline with name %s not found", name)
-}
-
-// resolveRunFileInWorkspace maps runFile from the current checkout to the same
-// repository-relative location inside targetWorkspace.
-func resolveRunFileInWorkspace(runFile, repoRoot, targetWorkspace string) (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	absRunFile := runFile
-	if !filepath.IsAbs(absRunFile) {
-		absRunFile = filepath.Join(cwd, runFile)
-	}
-	absRunFile = filepath.Clean(absRunFile)
-
-	rel, err := filepath.Rel(repoRoot, absRunFile)
-	if err != nil {
-		return "", err
-	}
-	if strings.HasPrefix(rel, "..") {
-		return "", fmt.Errorf("run file is outside repository: %s", runFile)
-	}
-
-	return filepath.Join(targetWorkspace, rel), nil
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -13,17 +13,18 @@ import (
 	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
 )
 
-var verifyCmd = &cobra.Command{
-	Use:                   "verify {pipeline-path|pipeline-directory}",
+var validateCmd = &cobra.Command{
+	Use:                   "validate {pipeline-path|pipeline-directory}",
 	Short:                 "Validate a pipeline file or directory",
 	Long:                  "Validate a single pipeline YAML file, or recursively validate all pipeline YAML files under a directory. The command stops at the first failure and prints the exact error location.",
-	Example:               "cicd verify ./.pipelines/build.yaml\ncicd verify ./.pipelines",
+	Example:               "cicd validate ./.pipelines/build.yaml\ncicd validate ./.pipelines",
 	Args:                  cobra.ExactArgs(1),
-	RunE:                  runVerify,
+	RunE:                  runValidate,
+	Aliases:               []string{"verify"},
 	DisableFlagsInUseLine: true,
 }
 
-func runVerify(cmd *cobra.Command, args []string) error {
+func runValidate(cmd *cobra.Command, args []string) error {
 	repo, err := gitutil.Open(".")
 	if err != nil {
 		return err
@@ -44,10 +45,10 @@ func runVerify(cmd *cobra.Command, args []string) error {
 
 	gatewayClient := NewGatewayClient()
 	if info.IsDir() {
-		return verifyPipelineDir(completePath, gatewayClient)
+		return validatePipelineDir(completePath, gatewayClient)
 	}
 
-	valid, err := verifySinglePipeline(completePath, gatewayClient)
+	valid, err := validateSinglePipeline(completePath, gatewayClient)
 	if err != nil {
 		return err
 	}
@@ -58,7 +59,7 @@ func runVerify(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func verifyPipelineDir(dir string, gatewayClient *GatewayClient) error {
+func validatePipelineDir(dir string, gatewayClient *GatewayClient) error {
 	targets, err := collectYAMLFiles(dir)
 	if err != nil {
 		return fmt.Errorf("failed to enumerate directory %q: %w", dir, err)
@@ -70,7 +71,7 @@ func verifyPipelineDir(dir string, gatewayClient *GatewayClient) error {
 	sort.Strings(targets)
 
 	for _, target := range targets {
-		valid, err := verifySinglePipeline(target, gatewayClient)
+		valid, err := validateSinglePipeline(target, gatewayClient)
 		if err != nil {
 			// Fast fail: stop at the first invalid file or validation request error.
 			return err
@@ -84,7 +85,7 @@ func verifyPipelineDir(dir string, gatewayClient *GatewayClient) error {
 	return nil
 }
 
-func verifySinglePipeline(pipelinePath string, gatewayClient *GatewayClient) (bool, error) {
+func validateSinglePipeline(pipelinePath string, gatewayClient *GatewayClient) (bool, error) {
 	fileContent, err := os.ReadFile(pipelinePath)
 	if err != nil {
 		return false, fmt.Errorf("failed to read file content %q: %w", pipelinePath, err)

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -26,9 +26,9 @@ var validateCmd = &cobra.Command{
 }
 
 func runValidate(cmd *cobra.Command, args []string) error {
-	repo, ok := cmd.Context().Value(repoKey).(*gitutil.Repository)
-	if !ok || repo == nil {
-		return fmt.Errorf("git repository context is missing")
+	repo, err := repoFromCommandContext(cmd)
+	if err != nil {
+		return err
 	}
 	rootDir := repo.Root()
 
@@ -42,14 +42,14 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get head commit failed: %w", err)
 	}
 
+	gatewayClient := NewGatewayClient()
+	if info.IsDir() {
+		return validatePipelineDir(repo, completePath, gatewayClient, commit)
+	}
+
 	pipelineData, err := repo.ReadFileAtCommit(commit, completePath)
 	if err != nil {
 		return fmt.Errorf("read pipeline file failed: %w", err)
-	}
-
-	gatewayClient := NewGatewayClient()
-	if info.IsDir() {
-		return validatePipelineDir(completePath, gatewayClient, commit, pipelineData)
 	}
 
 	valid, err := validateSinglePipeline(completePath, gatewayClient, commit, pipelineData)
@@ -63,7 +63,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func validatePipelineDir(dir string, gatewayClient *GatewayClient, commit string, pipelineData []byte) error {
+func validatePipelineDir(repo *gitutil.Repository, dir string, gatewayClient *GatewayClient, commit string) error {
 	targets, err := collectYAMLFiles(dir)
 	if err != nil {
 		return fmt.Errorf("failed to enumerate directory %q: %w", dir, err)
@@ -75,6 +75,11 @@ func validatePipelineDir(dir string, gatewayClient *GatewayClient, commit string
 	sort.Strings(targets)
 
 	for _, target := range targets {
+		pipelineData, err := repo.ReadFileAtCommit(commit, target)
+		if err != nil {
+			return fmt.Errorf("read pipeline file failed: %w", err)
+		}
+
 		valid, err := validateSinglePipeline(target, gatewayClient, commit, pipelineData)
 		if err != nil {
 			// Fast fail: stop at the first invalid file or validation request error.
@@ -93,8 +98,8 @@ func validateSinglePipeline(pipelinePath string, gatewayClient *GatewayClient, c
 	pipelinePath = filepath.Base(pipelinePath)
 
 	response, err := gatewayClient.Validate(api.ValidateRequest{
-		YAMLContent: string(pipelineData),
-		Commit:      commit,
+		YAMLContent:  string(pipelineData),
+		Commit:       commit,
 		PipelinePath: pipelinePath,
 	})
 	if err != nil {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/xueyulinn/cicd-system/internal/api"
 	"github.com/xueyulinn/cicd-system/internal/common/gitutil"
+	"github.com/xueyulinn/cicd-system/internal/common/pipelinepath"
 )
 
 var validateCmd = &cobra.Command{
@@ -31,16 +32,9 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	}
 	rootDir := repo.Root()
 
-	pipelinePath := args[0]
-	completePath := pipelinePath
-	if !filepath.IsAbs(pipelinePath) {
-		completePath = filepath.Join(rootDir, pipelinePath)
-	}
-	completePath = filepath.Clean(completePath)
-
-	info, err := os.Stat(completePath)
+	completePath, info, err := pipelinepath.ResolveInputPath(rootDir, args[0])
 	if err != nil {
-		return fmt.Errorf("failed to get the info of path %q: %w", completePath, err)
+		return err
 	}
 
 	gatewayClient := NewGatewayClient()
@@ -78,7 +72,7 @@ func validatePipelineDir(dir string, gatewayClient *GatewayClient) error {
 		}
 
 		if valid {
-			fmt.Printf("%s: Configuration is valid\n", target)
+			fmt.Printf("%s: pipeline is valid\n", target)
 		}
 	}
 

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -25,13 +25,13 @@ var validateCmd = &cobra.Command{
 }
 
 func runValidate(cmd *cobra.Command, args []string) error {
-	repo, err := gitutil.Open(".")
-	if err != nil {
-		return err
+	repo, ok := cmd.Context().Value(repoKey).(*gitutil.Repository)
+	if !ok || repo == nil {
+		return fmt.Errorf("git repository context is missing")
 	}
 	rootDir := repo.Root()
-	pipelinePath := args[0]
 
+	pipelinePath := args[0]
 	completePath := pipelinePath
 	if !filepath.IsAbs(pipelinePath) {
 		completePath = filepath.Join(rootDir, pipelinePath)
@@ -53,7 +53,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if valid {
-		fmt.Println("Configuration is valid")
+		fmt.Println("pipeline is valid")
 	}
 
 	return nil

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -37,12 +37,22 @@ func runValidate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	gatewayClient := NewGatewayClient()
-	if info.IsDir() {
-		return validatePipelineDir(completePath, gatewayClient)
+	commit, err := repo.GetHeadCommit()
+	if err != nil {
+		return fmt.Errorf("get head commit failed: %w", err)
 	}
 
-	valid, err := validateSinglePipeline(completePath, gatewayClient)
+	pipelineData, err := repo.ReadFileAtCommit(commit, completePath)
+	if err != nil {
+		return fmt.Errorf("read pipeline file failed: %w", err)
+	}
+
+	gatewayClient := NewGatewayClient()
+	if info.IsDir() {
+		return validatePipelineDir(completePath, gatewayClient, commit, pipelineData)
+	}
+
+	valid, err := validateSinglePipeline(completePath, gatewayClient, commit, pipelineData)
 	if err != nil {
 		return err
 	}
@@ -53,7 +63,7 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func validatePipelineDir(dir string, gatewayClient *GatewayClient) error {
+func validatePipelineDir(dir string, gatewayClient *GatewayClient, commit string, pipelineData []byte) error {
 	targets, err := collectYAMLFiles(dir)
 	if err != nil {
 		return fmt.Errorf("failed to enumerate directory %q: %w", dir, err)
@@ -65,7 +75,7 @@ func validatePipelineDir(dir string, gatewayClient *GatewayClient) error {
 	sort.Strings(targets)
 
 	for _, target := range targets {
-		valid, err := validateSinglePipeline(target, gatewayClient)
+		valid, err := validateSinglePipeline(target, gatewayClient, commit, pipelineData)
 		if err != nil {
 			// Fast fail: stop at the first invalid file or validation request error.
 			return err
@@ -79,13 +89,14 @@ func validatePipelineDir(dir string, gatewayClient *GatewayClient) error {
 	return nil
 }
 
-func validateSinglePipeline(pipelinePath string, gatewayClient *GatewayClient) (bool, error) {
-	fileContent, err := os.ReadFile(pipelinePath)
-	if err != nil {
-		return false, fmt.Errorf("failed to read file content %q: %w", pipelinePath, err)
-	}
+func validateSinglePipeline(pipelinePath string, gatewayClient *GatewayClient, commit string, pipelineData []byte) (bool, error) {
+	pipelinePath = filepath.Base(pipelinePath)
 
-	response, err := gatewayClient.Validate(api.ValidateRequest{YAMLContent: string(fileContent)})
+	response, err := gatewayClient.Validate(api.ValidateRequest{
+		YAMLContent: string(pipelineData),
+		Commit:      commit,
+		PipelinePath: pipelinePath,
+	})
 	if err != nil {
 		return false, fmt.Errorf("failed to verify %q: %w", pipelinePath, err)
 	}

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -28,6 +28,16 @@ func writeTempPipelineInGitRepo(t *testing.T, content string) (configPath string
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("git init failed: %v", err)
 	}
+	addCmd := exec.Command("git", "add", ".")
+	addCmd.Dir = tmpDir
+	if err := addCmd.Run(); err != nil {
+		t.Fatalf("git add failed: %v", err)
+	}
+	commitCmd := exec.Command("git", "-c", "user.name=test-user", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	commitCmd.Dir = tmpDir
+	if err := commitCmd.Run(); err != nil {
+		t.Fatalf("git commit failed: %v", err)
+	}
 	origWd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
@@ -140,6 +150,11 @@ func TestRunValidate_MissingFile_ReturnsError(t *testing.T) {
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("git init failed: %v", err)
+	}
+	commitCmd := exec.Command("git", "-c", "user.name=test-user", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "init")
+	commitCmd.Dir = tmpDir
+	if err := commitCmd.Run(); err != nil {
+		t.Fatalf("git commit failed: %v", err)
 	}
 	origWd, _ := os.Getwd()
 	if err := os.Chdir(tmpDir); err != nil {

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -15,7 +15,11 @@ import (
 func writeTempPipelineInGitRepo(t *testing.T, content string) (configPath string, cleanup func()) {
 	t.Helper()
 	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "pipeline.yaml")
+	pipelineDir := filepath.Join(tmpDir, ".pipelines")
+	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
+		t.Fatalf("Failed to create pipeline dir: %v", err)
+	}
+	path := filepath.Join(pipelineDir, "pipeline.yaml")
 	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o644); err != nil {
 		t.Fatalf("Failed to write pipeline file: %v", err)
 	}
@@ -61,6 +65,43 @@ compile:
 	}
 }
 
+func TestRunValidate_FromPipelinesWorkingDir_ValidFile(t *testing.T) {
+	startValidationGatewayServer(t)
+
+	_, cleanup := writeTempPipelineInGitRepo(t, `
+pipeline:
+  name: "Test Pipeline"
+
+stages:
+  - build
+
+compile:
+  - stage: build
+  - image: golang:1.21
+  - script:
+    - "go build"
+`)
+	defer cleanup()
+
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	pipelineDir := filepath.Join(repoRoot, ".pipelines")
+	if err := os.Chdir(pipelineDir); err != nil {
+		t.Fatalf("chdir pipeline dir: %v", err)
+	}
+	defer func() { _ = os.Chdir(repoRoot) }()
+
+	output, err := runValidateCommand(t, "pipeline.yaml")
+	if err != nil {
+		t.Fatalf("validate command returned error: %v", err)
+	}
+	if !strings.Contains(output, "pipeline is valid") {
+		t.Errorf("Expected success message in output, got:\n%s", output)
+	}
+}
+
 func TestRunValidate_InvalidFile_ReturnsError(t *testing.T) {
 	startValidationGatewayServer(t)
 
@@ -91,6 +132,10 @@ compile:
 
 func TestRunValidate_MissingFile_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
+	pipelineDir := filepath.Join(tmpDir, ".pipelines")
+	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
+		t.Fatalf("mkdir pipeline dir: %v", err)
+	}
 	cmd := exec.Command("git", "init")
 	cmd.Dir = tmpDir
 	if err := cmd.Run(); err != nil {
@@ -102,7 +147,7 @@ func TestRunValidate_MissingFile_ReturnsError(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(origWd) }()
 
-	configPath := filepath.Join(tmpDir, "does-not-exist.yaml")
+	configPath := filepath.Join(pipelineDir, "does-not-exist.yaml")
 
 	_, err := runValidateCommand(t, configPath)
 	if err == nil {

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -36,7 +36,7 @@ func writeTempPipelineInGitRepo(t *testing.T, content string) (configPath string
 	return path, func() { _ = os.Chdir(origWd) }
 }
 
-func TestRunVerify_ValidFile(t *testing.T) {
+func TestRunValidate_ValidFile(t *testing.T) {
 	startValidationGatewayServer(t)
 
 	configPath, cleanup := writeTempPipelineInGitRepo(t, `
@@ -55,17 +55,17 @@ compile:
 	defer cleanup()
 
 	output, err := captureStdout(t, func() error {
-		return runVerify(&cobra.Command{}, []string{configPath})
+		return runValidate(&cobra.Command{}, []string{configPath})
 	})
 	if err != nil {
-		t.Fatalf("runVerify returned error: %v", err)
+		t.Fatalf("runValidate returned error: %v", err)
 	}
 	if !strings.Contains(output, "Configuration is valid") {
 		t.Errorf("Expected success message in output, got:\n%s", output)
 	}
 }
 
-func TestRunVerify_InvalidFile_ReturnsError(t *testing.T) {
+func TestRunValidate_InvalidFile_ReturnsError(t *testing.T) {
 	startValidationGatewayServer(t)
 
 	configPath, cleanup := writeTempPipelineInGitRepo(t, `
@@ -85,7 +85,7 @@ compile:
 	defer cleanup()
 
 	_, err := captureStdout(t, func() error {
-		return runVerify(&cobra.Command{}, []string{configPath})
+		return runValidate(&cobra.Command{}, []string{configPath})
 	})
 	if err == nil {
 		t.Fatal("Expected error for stage with no jobs, got nil")
@@ -95,7 +95,7 @@ compile:
 	}
 }
 
-func TestRunVerify_MissingFile_ReturnsError(t *testing.T) {
+func TestRunValidate_MissingFile_ReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 	cmd := exec.Command("git", "init")
 	cmd.Dir = tmpDir
@@ -111,12 +111,12 @@ func TestRunVerify_MissingFile_ReturnsError(t *testing.T) {
 	configPath := filepath.Join(tmpDir, "does-not-exist.yaml")
 
 	_, err := captureStdout(t, func() error {
-		return runVerify(&cobra.Command{}, []string{configPath})
+		return runValidate(&cobra.Command{}, []string{configPath})
 	})
 	if err == nil {
 		t.Fatal("Expected error for missing file, got nil")
 	}
-	// runVerify returns the error from os.Stat (platform-specific message)
+	// runValidate returns the error from os.Stat (platform-specific message)
 	if !strings.Contains(err.Error(), "stat") &&
 		!strings.Contains(err.Error(), "no such file") &&
 		!strings.Contains(err.Error(), "GetFileAttributesEx") &&

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 // writeTempPipelineInGitRepo creates a temp dir, runs "git init", writes pipeline content
@@ -54,13 +52,11 @@ compile:
 `)
 	defer cleanup()
 
-	output, err := captureStdout(t, func() error {
-		return runValidate(&cobra.Command{}, []string{configPath})
-	})
+	output, err := runValidateCommand(t, configPath)
 	if err != nil {
-		t.Fatalf("runValidate returned error: %v", err)
+		t.Fatalf("validate command returned error: %v", err)
 	}
-	if !strings.Contains(output, "Configuration is valid") {
+	if !strings.Contains(output, "pipeline is valid") {
 		t.Errorf("Expected success message in output, got:\n%s", output)
 	}
 }
@@ -81,12 +77,10 @@ compile:
   - image: golang:1.21
   - script:
     - "go build"
-`)
+	`)
 	defer cleanup()
 
-	_, err := captureStdout(t, func() error {
-		return runValidate(&cobra.Command{}, []string{configPath})
-	})
+	_, err := runValidateCommand(t, configPath)
 	if err == nil {
 		t.Fatal("Expected error for stage with no jobs, got nil")
 	}
@@ -110,9 +104,7 @@ func TestRunValidate_MissingFile_ReturnsError(t *testing.T) {
 
 	configPath := filepath.Join(tmpDir, "does-not-exist.yaml")
 
-	_, err := captureStdout(t, func() error {
-		return runValidate(&cobra.Command{}, []string{configPath})
-	})
+	_, err := runValidateCommand(t, configPath)
 	if err == nil {
 		t.Fatal("Expected error for missing file, got nil")
 	}
@@ -123,6 +115,15 @@ func TestRunValidate_MissingFile_ReturnsError(t *testing.T) {
 		!strings.Contains(err.Error(), "cannot find the file") {
 		t.Errorf("Expected stat/no such file error, got: %v", err)
 	}
+}
+
+func runValidateCommand(t *testing.T, configPath string) (string, error) {
+	t.Helper()
+	cmd := *rootCmd
+	cmd.SetArgs([]string{"validate", configPath})
+	return captureStdout(t, func() error {
+		return cmd.Execute()
+	})
 }
 
 func captureStdout(t *testing.T, fn func() error) (string, error) {

--- a/internal/common/formatter/formatter.go
+++ b/internal/common/formatter/formatter.go
@@ -1,4 +1,4 @@
-package cli
+package formatter
 
 import (
 	"encoding/json"

--- a/internal/common/formatter/formatter_test.go
+++ b/internal/common/formatter/formatter_test.go
@@ -1,4 +1,4 @@
-package cli
+package formatter
 
 import (
 	"strings"
@@ -108,7 +108,6 @@ func TestFormatReportJSON_NilReport(t *testing.T) {
 	}
 }
 
-// TestFormatReportYAML_JobFailuresField verifies that job output always includes the failures field.
 func TestFormatReportYAML_JobFailuresField(t *testing.T) {
 	start := time.Date(2025, 9, 1, 10, 0, 0, 0, time.UTC)
 	end := time.Date(2025, 9, 1, 10, 5, 0, 0, time.UTC)

--- a/internal/common/gitutil/gitutil.go
+++ b/internal/common/gitutil/gitutil.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v6"
@@ -107,6 +108,68 @@ func (r *Repository) CreateDetachedWorktree(commit string) (string, func(), erro
 		_ = os.RemoveAll(tmpDir)
 	}
 	return tmpDir, cleanup, nil
+}
+
+// ReadFileAtCommit reads filePath from the given commit via a temporary
+// detached worktree and removes that worktree before returning. filePath may
+// be absolute or relative to the current working directory, but it must
+// resolve inside the repository.
+func (r *Repository) ReadFileAtCommit(commit, filePath string) ([]byte, error) {
+	commit = strings.TrimSpace(commit)
+	filePath = strings.TrimSpace(filePath)
+	if commit == "" {
+		return nil, fmt.Errorf("commit is required")
+	}
+	if filePath == "" {
+		return nil, fmt.Errorf("file path is required")
+	}
+
+	relPath, err := r.resolveRepoRelativePath(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	worktreeDir, cleanup, err := r.CreateDetachedWorktree(commit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare workspace for commit %q: %w", commit, err)
+	}
+	defer cleanup()
+
+	targetPath := filepath.Join(worktreeDir, relPath)
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %q at commit %q: %w", filePath, commit, err)
+	}
+
+	return content, nil
+}
+
+func (r *Repository) resolveRepoRelativePath(filePath string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	absPath := filePath
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(cwd, filePath)
+	}
+	absPath = filepath.Clean(absPath)
+
+	relPath, err := filepath.Rel(r.root, absPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve file %q relative to repository root: %w", filePath, err)
+	}
+	relPath = filepath.Clean(relPath)
+	if pathEscapesParent(relPath) {
+		return "", fmt.Errorf("file is outside repository: %s", filePath)
+	}
+
+	return relPath, nil
+}
+
+func pathEscapesParent(path string) bool {
+	return path == ".." || strings.HasPrefix(path, ".."+string(os.PathSeparator))
 }
 
 func (r *Repository) BranchContainsCommit(branch string, commitSHA string) (bool, error) {

--- a/internal/common/gitutil/gitutil_test.go
+++ b/internal/common/gitutil/gitutil_test.go
@@ -12,6 +12,63 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
+func TestReadFileAtCommit_ReturnsContentFromTargetCommit(t *testing.T) {
+	repoDir, firstCommit, secondCommit := setupRepoWithFileHistory(t)
+
+	repo, err := Open(repoDir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	pipelineDir := filepath.Join(repoDir, ".pipelines")
+	if err := os.Chdir(pipelineDir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origWD) }()
+
+	firstContent, err := repo.ReadFileAtCommit(firstCommit, "build.yaml")
+	if err != nil {
+		t.Fatalf("ReadFileAtCommit(first): %v", err)
+	}
+	if got := string(firstContent); got != "version: one\n" {
+		t.Fatalf("unexpected first commit content: %q", got)
+	}
+
+	secondContent, err := repo.ReadFileAtCommit(secondCommit, "build.yaml")
+	if err != nil {
+		t.Fatalf("ReadFileAtCommit(second): %v", err)
+	}
+	if got := string(secondContent); got != "version: two\n" {
+		t.Fatalf("unexpected second commit content: %q", got)
+	}
+}
+
+func TestReadFileAtCommit_RejectsPathOutsideRepository(t *testing.T) {
+	repoDir, commit, _ := setupRepoWithFileHistory(t)
+
+	repo, err := Open(repoDir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	outsideFile := filepath.Join(t.TempDir(), "outside.yaml")
+	if err := os.WriteFile(outsideFile, []byte("outside\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err = repo.ReadFileAtCommit(commit, outsideFile)
+	if err == nil {
+		t.Fatal("expected error for file outside repository")
+	}
+	if !strings.Contains(err.Error(), "outside repository") {
+		t.Fatalf("expected outside repository error, got: %v", err)
+	}
+}
+
 func TestRemoteBranchContainsCommit_RemoteNotFound(t *testing.T) {
 	cloneDir, _, _ := setupLocalRemoteClone(t)
 
@@ -120,4 +177,60 @@ func localPathToFileURL(path string) string {
 		return "file:///" + slashed
 	}
 	return "file://" + slashed
+}
+
+func setupRepoWithFileHistory(t *testing.T) (repoDir, firstCommit, secondCommit string) {
+	t.Helper()
+
+	repoDir = t.TempDir()
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+
+	pipelineFile := filepath.Join(repoDir, ".pipelines", "build.yaml")
+	if err := os.MkdirAll(filepath.Dir(pipelineFile), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	if err := os.WriteFile(pipelineFile, []byte("version: one\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(first): %v", err)
+	}
+	if _, err := worktree.Add(".pipelines/build.yaml"); err != nil {
+		t.Fatalf("Add(first): %v", err)
+	}
+	firstHash, err := worktree.Commit("first", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test-user",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Commit(first): %v", err)
+	}
+
+	if err := os.WriteFile(pipelineFile, []byte("version: two\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(second): %v", err)
+	}
+	if _, err := worktree.Add(".pipelines/build.yaml"); err != nil {
+		t.Fatalf("Add(second): %v", err)
+	}
+	secondHash, err := worktree.Commit("second", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test-user",
+			Email: "test@example.com",
+			When:  time.Now().Add(time.Second),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Commit(second): %v", err)
+	}
+
+	return repoDir, firstHash.String(), secondHash.String()
 }

--- a/internal/common/pipelinepath/resolver.go
+++ b/internal/common/pipelinepath/resolver.go
@@ -1,0 +1,137 @@
+package pipelinepath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/xueyulinn/cicd-system/internal/config"
+)
+
+// ResolveInputPath normalizes a validate/dryrun input path so file inputs
+// resolve under the repository's .pipelines directory while directory inputs
+// only allow the .pipelines root itself.
+func ResolveInputPath(rootDir, inputPath string) (string, os.FileInfo, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	return resolveInputPathFromWorkingDir(rootDir, cwd, inputPath)
+}
+
+func resolveInputPathFromWorkingDir(rootDir, workingDir, inputPath string) (string, os.FileInfo, error) {
+	pipelineRoot := filepath.Join(rootDir, config.DefaultPipelineDir)
+
+	cleanInput := filepath.Clean(strings.TrimSpace(inputPath))
+	if strings.TrimSpace(inputPath) == "" {
+		return "", nil, fmt.Errorf("pipeline path must not be empty")
+	}
+
+	absoluteInputPath := cleanInput
+	if !filepath.IsAbs(cleanInput) {
+		if isPipelineRootRelativePath(cleanInput) {
+			absoluteInputPath = filepath.Join(rootDir, cleanInput)
+		} else {
+			absoluteInputPath = filepath.Join(workingDir, cleanInput)
+		}
+	}
+	absoluteInputPath = filepath.Clean(absoluteInputPath)
+
+	repoRelativeInput, err := toRepoRelativePipelinePath(rootDir, absoluteInputPath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	explicitRepoPath := filepath.Clean(filepath.Join(rootDir, repoRelativeInput))
+	explicitInfo, explicitErr := os.Stat(explicitRepoPath)
+	if explicitErr == nil {
+		if repoRelativeInput == config.DefaultPipelineDir {
+			if !explicitInfo.IsDir() {
+				return "", nil, fmt.Errorf("pipeline directory %q is not a directory", pipelineRoot)
+			}
+			return pipelineRoot, explicitInfo, nil
+		}
+
+		if isPathWithinDir(pipelineRoot, explicitRepoPath) {
+			if explicitInfo.IsDir() {
+				return "", nil, fmt.Errorf("pipeline directory must be %q", config.DefaultPipelineDir)
+			}
+			return explicitRepoPath, explicitInfo, nil
+		}
+
+		if explicitInfo.IsDir() {
+			return "", nil, fmt.Errorf("pipeline directory must be %q", config.DefaultPipelineDir)
+		}
+
+		return "", nil, fmt.Errorf("pipeline file must be inside %q: %s", config.DefaultPipelineDir, inputPath)
+	}
+	if !os.IsNotExist(explicitErr) {
+		return "", nil, fmt.Errorf("failed to get the info of path %q: %w", explicitRepoPath, explicitErr)
+	}
+
+	if repoRelativeInput == config.DefaultPipelineDir || isPathWithinDir(pipelineRoot, explicitRepoPath) {
+		return "", nil, fmt.Errorf("failed to get the info of path %q: %w", explicitRepoPath, explicitErr)
+	}
+
+	if filepath.IsAbs(cleanInput) {
+		return "", nil, fmt.Errorf("pipeline file must be inside %q: %s", config.DefaultPipelineDir, inputPath)
+	}
+	if pathEscapesParent(cleanInput) {
+		return "", nil, fmt.Errorf("pipeline file must be inside %q: %s", config.DefaultPipelineDir, inputPath)
+	}
+
+	finalPath := filepath.Clean(filepath.Join(pipelineRoot, cleanInput))
+	if !isPathWithinDir(pipelineRoot, finalPath) {
+		return "", nil, fmt.Errorf("pipeline path escapes %q: %s", config.DefaultPipelineDir, inputPath)
+	}
+
+	info, err := statPipelineTarget(finalPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if info.IsDir() {
+		return "", nil, fmt.Errorf("pipeline directory must be %q", config.DefaultPipelineDir)
+	}
+
+	return finalPath, info, nil
+}
+
+func toRepoRelativePipelinePath(rootDir, inputPath string) (string, error) {
+	rel, err := filepath.Rel(rootDir, inputPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve pipeline path %q relative to repository root: %w", inputPath, err)
+	}
+	rel = filepath.Clean(rel)
+	if pathEscapesParent(rel) {
+		return "", fmt.Errorf("pipeline path must stay within the repository: %s", inputPath)
+	}
+
+	return rel, nil
+}
+
+func statPipelineTarget(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the info of path %q: %w", path, err)
+	}
+	return info, nil
+}
+
+func isPathWithinDir(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	rel = filepath.Clean(rel)
+	return rel == "." || !pathEscapesParent(rel)
+}
+
+func pathEscapesParent(path string) bool {
+	return path == ".." || strings.HasPrefix(path, ".."+string(os.PathSeparator))
+}
+
+func isPipelineRootRelativePath(path string) bool {
+	return path == config.DefaultPipelineDir || strings.HasPrefix(path, config.DefaultPipelineDir+string(os.PathSeparator))
+}

--- a/internal/common/pipelinepath/resolver_test.go
+++ b/internal/common/pipelinepath/resolver_test.go
@@ -1,0 +1,135 @@
+package pipelinepath
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveInputPath_FileNameMapsToPipelinesDir(t *testing.T) {
+	rootDir := t.TempDir()
+	pipelineFile := filepath.Join(rootDir, ".pipelines", "build.yaml")
+	mustWritePipelineFile(t, pipelineFile)
+
+	resolved, info, err := resolveInputPathFromWorkingDir(rootDir, rootDir, "build.yaml")
+	if err != nil {
+		t.Fatalf("resolveInputPathFromWorkingDir returned error: %v", err)
+	}
+	if resolved != pipelineFile {
+		t.Fatalf("expected %q, got %q", pipelineFile, resolved)
+	}
+	if info.IsDir() {
+		t.Fatal("expected file target, got directory")
+	}
+}
+
+func TestResolveInputPath_DotPipelinesDirectoryAllowed(t *testing.T) {
+	rootDir := t.TempDir()
+	pipelineDir := filepath.Join(rootDir, ".pipelines")
+	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
+		t.Fatalf("mkdir pipeline dir: %v", err)
+	}
+
+	resolved, info, err := resolveInputPathFromWorkingDir(rootDir, rootDir, ".pipelines")
+	if err != nil {
+		t.Fatalf("resolveInputPathFromWorkingDir returned error: %v", err)
+	}
+	if resolved != pipelineDir {
+		t.Fatalf("expected %q, got %q", pipelineDir, resolved)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected directory target, got file")
+	}
+}
+
+func TestResolveInputPath_RejectsNestedDirectoryInput(t *testing.T) {
+	rootDir := t.TempDir()
+	nestedDir := filepath.Join(rootDir, ".pipelines", "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+
+	_, _, err := resolveInputPathFromWorkingDir(rootDir, rootDir, ".pipelines/nested")
+	if err == nil {
+		t.Fatal("expected error for nested directory input, got nil")
+	}
+	if !strings.Contains(err.Error(), `pipeline directory must be ".pipelines"`) {
+		t.Fatalf("expected directory restriction error, got: %v", err)
+	}
+}
+
+func TestResolveInputPath_RejectsAbsoluteFileOutsidePipelines(t *testing.T) {
+	rootDir := t.TempDir()
+	outsideFile := filepath.Join(rootDir, "build.yaml")
+	if err := os.WriteFile(outsideFile, []byte("pipeline: {}\n"), 0o644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	_, _, err := resolveInputPathFromWorkingDir(rootDir, rootDir, outsideFile)
+	if err == nil {
+		t.Fatal("expected error for absolute file outside .pipelines, got nil")
+	}
+	if !strings.Contains(err.Error(), `pipeline file must be inside ".pipelines"`) {
+		t.Fatalf("expected outside-pipelines error, got: %v", err)
+	}
+}
+
+func TestResolveInputPath_RejectsParentEscape(t *testing.T) {
+	rootDir := t.TempDir()
+
+	_, _, err := resolveInputPathFromWorkingDir(rootDir, rootDir, "../build.yaml")
+	if err == nil {
+		t.Fatal("expected error for parent escape, got nil")
+	}
+	if !strings.Contains(err.Error(), "must stay within the repository") {
+		t.Fatalf("expected repository boundary error, got: %v", err)
+	}
+}
+
+func TestResolveInputPath_FromPipelinesWorkingDir_FileNameResolvesInPlace(t *testing.T) {
+	rootDir := t.TempDir()
+	pipelineDir := filepath.Join(rootDir, ".pipelines")
+	pipelineFile := filepath.Join(pipelineDir, "build.yaml")
+	mustWritePipelineFile(t, pipelineFile)
+
+	resolved, info, err := resolveInputPathFromWorkingDir(rootDir, pipelineDir, "build.yaml")
+	if err != nil {
+		t.Fatalf("resolveInputPathFromWorkingDir returned error: %v", err)
+	}
+	if resolved != pipelineFile {
+		t.Fatalf("expected %q, got %q", pipelineFile, resolved)
+	}
+	if info.IsDir() {
+		t.Fatal("expected file target, got directory")
+	}
+}
+
+func TestResolveInputPath_FromPipelinesWorkingDir_DotResolvesPipelineDir(t *testing.T) {
+	rootDir := t.TempDir()
+	pipelineDir := filepath.Join(rootDir, ".pipelines")
+	if err := os.MkdirAll(pipelineDir, 0o755); err != nil {
+		t.Fatalf("mkdir pipeline dir: %v", err)
+	}
+
+	resolved, info, err := resolveInputPathFromWorkingDir(rootDir, pipelineDir, ".")
+	if err != nil {
+		t.Fatalf("resolveInputPathFromWorkingDir returned error: %v", err)
+	}
+	if resolved != pipelineDir {
+		t.Fatalf("expected %q, got %q", pipelineDir, resolved)
+	}
+	if !info.IsDir() {
+		t.Fatal("expected directory target, got file")
+	}
+}
+
+func mustWritePipelineFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir pipeline parent: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("pipeline: {}\n"), 0o644); err != nil {
+		t.Fatalf("write pipeline file: %v", err)
+	}
+}

--- a/internal/services/validation/handler.go
+++ b/internal/services/validation/handler.go
@@ -63,7 +63,7 @@ func (h *Handler) handleValidate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	response := h.service.ValidateYAML(ctx, req.YAMLContent)
+	response := h.service.ValidateYAML(ctx, &req)
 
 	api.WriteJSON(w, http.StatusOK, response)
 }
@@ -89,7 +89,7 @@ func (h *Handler) handleDryRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	response := h.service.DryRunYAML(ctx, req.YAMLContent)
+	response := h.service.DryRunYAML(ctx, &req)
 
 	api.WriteJSON(w, http.StatusOK, response)
 }

--- a/internal/services/validation/service.go
+++ b/internal/services/validation/service.go
@@ -55,8 +55,8 @@ func validatePipelineContent(yamlContent string) (*models.Pipeline, []string) {
 }
 
 // ValidateYAML validates YAML pipeline content.
-func (s *Service) ValidateYAML(ctx context.Context, yamlContent string) api.ValidateResponse {
-	key := cache.ValidateKey(s.cacheCfg.KeyPrefix, yamlContent)
+func (s *Service) ValidateYAML(ctx context.Context, req *api.ValidateRequest) api.ValidateResponse {
+	key := cache.ValidateKey(s.cacheCfg.KeyPrefix, req.PipelinePath, req.Commit)
 
 	val, err := s.cacheStore.Get(ctx, key)
 	if err == nil {
@@ -71,7 +71,7 @@ func (s *Service) ValidateYAML(ctx context.Context, yamlContent string) api.Vali
 		slog.Warn("validation cache get failed; fallback to compute", "error", err)
 	}
 
-	_, errs := validatePipelineContent(yamlContent)
+	_, errs := validatePipelineContent(req.YAMLContent)
 	response := api.ValidateResponse{
 		Valid:  len(errs) == 0,
 		Errors: errs,
@@ -91,8 +91,8 @@ func (s *Service) ValidateYAML(ctx context.Context, yamlContent string) api.Vali
 }
 
 // DryRunYAML validates YAML and returns dry run output.
-func (s *Service) DryRunYAML(ctx context.Context, yamlContent string) api.DryRunResponse {
-	key := cache.DryRunKey(s.cacheCfg.KeyPrefix, yamlContent)
+func (s *Service) DryRunYAML(ctx context.Context, req *api.ValidateRequest) api.DryRunResponse {
+	key := cache.DryRunKey(s.cacheCfg.KeyPrefix, req.PipelinePath, req.Commit)
 
 	val, err := s.cacheStore.Get(ctx, key)
 	if err == nil {
@@ -107,7 +107,7 @@ func (s *Service) DryRunYAML(ctx context.Context, yamlContent string) api.DryRun
 		slog.Warn("dryrun cache get failed; fallback to compute", "error", err)
 	}
 
-	pipeline, errors := validatePipelineContent(yamlContent)
+	pipeline, errors := validatePipelineContent(req.YAMLContent)
 	if len(errors) > 0 {
 		return api.DryRunResponse{
 			Valid:  false,

--- a/internal/services/validation/service_test.go
+++ b/internal/services/validation/service_test.go
@@ -3,6 +3,8 @@ package validation
 import (
 	"context"
 	"testing"
+
+	"github.com/xueyulinn/cicd-system/internal/api"
 )
 
 func TestValidateYAMLValidPipeline(t *testing.T) {
@@ -13,7 +15,7 @@ func TestValidateYAMLValidPipeline(t *testing.T) {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	resp := svc.ValidateYAML(context.Background(), validPipelineYAML)
+	resp := svc.ValidateYAML(context.Background(), newValidateRequest(validPipelineYAML))
 	if !resp.Valid {
 		t.Fatalf("ValidateYAML valid = false, errors = %+v", resp.Errors)
 	}
@@ -27,7 +29,7 @@ func TestValidateYAMLInvalidPipeline(t *testing.T) {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	resp := svc.ValidateYAML(context.Background(), invalidPipelineYAML)
+	resp := svc.ValidateYAML(context.Background(), newValidateRequest(invalidPipelineYAML))
 	if resp.Valid {
 		t.Fatal("expected invalid response")
 	}
@@ -44,7 +46,7 @@ func TestDryRunYAMLValidPipeline(t *testing.T) {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	resp := svc.DryRunYAML(context.Background(), validPipelineYAML)
+	resp := svc.DryRunYAML(context.Background(), newValidateRequest(validPipelineYAML))
 	if !resp.Valid {
 		t.Fatalf("DryRunYAML valid = false, errors = %+v", resp.Errors)
 	}
@@ -58,7 +60,7 @@ func TestDryRunYAMLInvalidPipeline(t *testing.T) {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	resp := svc.DryRunYAML(context.Background(), invalidPipelineYAML)
+	resp := svc.DryRunYAML(context.Background(), newValidateRequest(invalidPipelineYAML))
 	if resp.Valid {
 		t.Fatal("expected invalid response")
 	}
@@ -75,11 +77,19 @@ func TestValidateYAMLParserError(t *testing.T) {
 		t.Fatalf("NewService() error = %v", err)
 	}
 
-	resp := svc.ValidateYAML(context.Background(), ":::")
+	resp := svc.ValidateYAML(context.Background(), newValidateRequest(":::"))
 	if resp.Valid {
 		t.Fatal("expected invalid response for malformed YAML")
 	}
 	if len(resp.Errors) == 0 {
 		t.Fatal("expected parser errors")
+	}
+}
+
+func newValidateRequest(yamlContent string) *api.ValidateRequest {
+	return &api.ValidateRequest{
+		YAMLContent:  yamlContent,
+		Commit:       "abc123",
+		PipelinePath: "build.yaml",
 	}
 }

--- a/load-tests/config/validate.js
+++ b/load-tests/config/validate.js
@@ -1,7 +1,7 @@
 import { yamlGenerationConfig } from "./yaml.js";
 import { generateRandomYAMLContent } from "../utils/yaml.js";
 
-const DEFAULT_BASE_URL = "http://localhost:8000";
+const DEFAULT_BASE_URL = "http://localhost:8001";
 const DEFAULT_VALIDATE_PATH = "/validate";
 const DEFAULT_THINK_TIME = 0;
 

--- a/observability/loki/loki-config.yml
+++ b/observability/loki/loki-config.yml
@@ -14,7 +14,7 @@ schema_config:
   configs:
     - from: 2026-01-01
       store: tsdb
-      object_store: filesystem
+      object_store: s3
       schema: v13
       index:
         # index_2024-04-22 
@@ -22,8 +22,15 @@ schema_config:
         period: 24h
 
 storage_config:
-  filesystem:
-    directory: /loki/chunks
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+  aws:
+    bucketnames: ${S3_BUCKET}
+    region: ${AWS_REGION}
+    access_key_id: ${AWS_ACCESS_KEY_ID}
+    secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 
 limits_config:
   # enable log to contain key-value metadata e.g. Otel log attributes
@@ -33,6 +40,14 @@ limits_config:
 
 compactor:
   working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: s3
+
+ingester:
+  chunk_idle_period: 30m
+  max_chunk_age: 2h
+  chunk_target_size: 1.5MB
+  chunk_retain_period: 0s
 
 analytics:
   # not report data used to Grafana


### PR DESCRIPTION
• ## Summary

This PR standardizes pipeline resolution under .pipelines, makes validate and dryrun commit-aware, updates validation caching to use pipeline_path + commit, and folds in related platform, observability, infrastructure, and load-testing refactors.

  ## Changes

  - Standardized CLI pipeline handling: migrated verify to validate, improved command descriptions, added shared repo-context loading, moved reusable formatter/path-resolution logic into internal/common, and made validate/dryrun resolve files consistently
    from .pipelines.
  - Updated validation request flow: validate and dryrun now send yaml_content, commit, and pipeline_path; validation file reads now come from the target commit via git worktrees; validation output now reports the file basename instead of full absolute paths.
  - Added Redis-backed validation caching: introduced cache config/store/key helpers, integrated cache reads/writes into validation and dry-run flows, and changed cache keys from raw pipeline content to pipeline_path + commit.
  - Refactored runtime/service internals: improved error-response handling across services, cleaned up gateway/reporting flows, renamed and reshaped execution/orchestration code toward orchestrator, and strengthened MQ reconnect/publisher/retry behavior.
  - Refreshed platform infrastructure: replaced PostgreSQL-related pieces with MySQL where needed, added Redis support to Docker Compose and Helm, renamed the Helm chart from e-team to cicd, and removed obsolete assets such as coverage, promtail, and legacy
    generated binaries/files.
  - Continued observability migration: expanded OpenTelemetry-based tracing/metrics/logging, centralized HTTP instrumentation, and updated Loki, Tempo, Prometheus, and collector configuration.
  - Expanded quality and performance coverage: added structured k6 load-test configs/scenarios for validate, dryrun, and run; added random pipeline generation and smoke/average-load/stress/soak/spike/breakpoint coverage; refreshed unit tests across gateway,
    validation, cache, gitutil, MQ, parser/planner/verifier, and CLI path resolution.
  - Updated project documentation and templates: refreshed README/README.zh-CN, FeatureStatus, design/release/verification docs, and added GitHub issue/PR templates while removing outdated weekly reports and stale docs.

  ## Result

  - Pipeline validation and dry-run behavior is now consistent end to end: path resolution is standardized, pipeline content can be loaded from a specific commit, and downstream validation requests carry stable path/commit metadata.
  - Validation-service caching is now safer and more reusable because cache identity is derived from pipeline location plus commit instead of the full YAML payload.
  - Operational consistency is improved through cleaner orchestrator/service boundaries, more robust MQ handling, standardized OTel observability, and updated Docker/Helm support for MySQL and Redis.
  - The branch also leaves the repository in a better maintenance state with broader automated coverage, repeatable load-test assets, and documentation/templates aligned with the current architecture.

  ## Testing

  - Added or updated automated coverage for CLI path resolution, gateway client/handler behavior, validation-service request/caching behavior, cache key generation, git worktree file loading, MQ retry/publish flows, and orchestrator-related paths.
  - Added k6 suites for validate, dryrun, and run under load-tests/.
  - Spot checks re-run while preparing this PR draft: go test ./internal/cli
  - Spot checks re-run while preparing this PR draft: go test ./internal/common/gitutil
  - Spot checks re-run while preparing this PR draft: go test ./internal/cache ./internal/services/validation